### PR TITLE
Fix Pawn Promotion Prompt

### DIFF
--- a/src/chess/Move.java
+++ b/src/chess/Move.java
@@ -21,6 +21,11 @@ public class Move {
 				| (doublePawnPushFlag << 21) | (enPassantFlag << 22) | (castleFlag << 23);
 	}
 
+	public static final int encodeNewPromotion(int move, int promotedPiece) {
+		return encodeMove(getSrc(move), getDst(move), getPiece(move), promotedPiece, getCaptureFlag(move),
+				getDoublePawnPushFlag(move), getEnPassantFlag(move), getCastleFlag(move));
+	}
+
 	public static final int scoreMove(Position pos, int moveEncoding) {
 		if (getCaptureFlag(moveEncoding) != 0) {
 			int targetPiece = PieceType.WPAWN.getKey();

--- a/src/event/ChessEvent.java
+++ b/src/event/ChessEvent.java
@@ -1,0 +1,15 @@
+package event;
+
+public abstract class ChessEvent {
+
+	private int targetSquare;
+
+	public ChessEvent(int targetSquare) {
+		this.targetSquare = targetSquare;
+	}
+
+	public int getTargetSquare() {
+		return targetSquare;
+	}
+
+}

--- a/src/event/ChessEventListener.java
+++ b/src/event/ChessEventListener.java
@@ -1,0 +1,7 @@
+package event;
+
+public interface ChessEventListener {
+
+	public void update(ChessEventType eventType, ChessEvent event);
+
+}

--- a/src/event/ChessEventManager.java
+++ b/src/event/ChessEventManager.java
@@ -1,0 +1,37 @@
+package event;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ChessEventManager {
+
+	private Map<ChessEventType, List<ChessEventListener>> listeners;
+
+	public ChessEventManager(ChessEventType... operations) {
+		listeners = new HashMap<>();
+		for (ChessEventType operation : operations) {
+			listeners.put(operation, new ArrayList<>());
+		}
+	}
+
+	public void subscribe(ChessEventListener listener, ChessEventType... operations) {
+		for (ChessEventType eventType : operations) {
+			listeners.get(eventType).add(listener);
+		}
+	}
+
+	public void unsubscribe(ChessEventType eventType, ChessEventListener listener) {
+		List<ChessEventListener> currentListeners = listeners.get(eventType);
+		currentListeners.remove(listener);
+	}
+
+	public void notify(ChessEventType eventType, ChessEvent event) {
+		List<ChessEventListener> currentListeners = listeners.get(eventType);
+		for (ChessEventListener listener : currentListeners) {
+			listener.update(eventType, event);
+		}
+	}
+
+}

--- a/src/event/ChessEventType.java
+++ b/src/event/ChessEventType.java
@@ -1,0 +1,7 @@
+package event;
+
+public enum ChessEventType {
+
+	PAWN_PROMOTION
+
+}

--- a/src/event/PawnPromotionEvent.java
+++ b/src/event/PawnPromotionEvent.java
@@ -1,0 +1,27 @@
+package event;
+
+import chess.PieceType;
+
+public class PawnPromotionEvent extends ChessEvent {
+
+	private PieceType promotedPiece;
+	private int color;
+
+	public PawnPromotionEvent(int targetSquare, int color) {
+		super(targetSquare);
+		this.color = color;
+	}
+
+	public void setPromotionResponse(PieceType promotedPiece) {
+		this.promotedPiece = promotedPiece;
+	}
+
+	public PieceType getPromotedPiece() {
+		return promotedPiece;
+	}
+
+	public int getColor() {
+		return color;
+	}
+
+}

--- a/src/game/GameState.java
+++ b/src/game/GameState.java
@@ -1,7 +1,0 @@
-package game;
-
-public enum GameState {
-
-	MENU, HUMAN_TURN, COMPUTER_TURN, PAWN_PROMOTION, CHECKMATE, STALEMATE;
-
-}

--- a/src/gui/ChessPanel.java
+++ b/src/gui/ChessPanel.java
@@ -10,10 +10,9 @@ import java.awt.event.MouseMotionAdapter;
 
 import javax.swing.JPanel;
 
-import chess.Piece;
+import event.ChessEventType;
 import game.GameManager;
 import game.GameMode;
-import game.GameState;
 import game.MoveType;
 import ui.SoundManager;
 import ui.UI;
@@ -63,7 +62,8 @@ public class ChessPanel extends JPanel {
 		userInterface = new UI();
 		soundManager = new SoundManager();
 		gameManager = new GameManager(gameMode, playerColor);
-		chessBoardPainter = new ChessBoardPainter(playerColor);
+		chessBoardPainter = new ChessBoardPainter(this);
+		gameManager.getChessEventManager().subscribe(chessBoardPainter, ChessEventType.values());
 		add(userInterface.moveLogPane);
 	}
 
@@ -86,7 +86,6 @@ public class ChessPanel extends JPanel {
 		int rank = (e.getY() / ChessBoardPainter.TILE_SIZE) - ChessBoardPainter.START_RANK;
 		int file = (e.getX() / ChessBoardPainter.TILE_SIZE) - ChessBoardPainter.START_FILE;
 		if (rank < 0 || rank > 7 || file < 0 || file > 7) {
-			gameManager.setGameState(GameState.HUMAN_TURN);
 			gameManager.resetActivePiecePosition();
 			gameManager.setSelectedSquare(-1);
 			return;
@@ -104,11 +103,6 @@ public class ChessPanel extends JPanel {
 		repaint();
 	}
 
-	public void requestPiecePromotion(Graphics2D graphics2D) {
-		chessBoardPainter.drawPiecePromotionPrompt(graphics2D, Piece.WHITE, gameManager.getPromotedPiece());
-		repaint();
-	}
-
 	@Override
 	protected void paintComponent(Graphics g) {
 		super.paintComponent(g);
@@ -123,9 +117,6 @@ public class ChessPanel extends JPanel {
 		chessBoardPainter.highlightSelectedSquare(graphics2D, gameManager.getSelectedSquare());
 		chessBoardPainter.drawPieces(graphics2D, gameManager.getPosition());
 		userInterface.updateMoveLog(gameManager.getMoveLog());
-		if (gameManager.getGameState() == GameState.PAWN_PROMOTION) {
-			requestPiecePromotion(graphics2D);
-		}
 
 		graphics2D.dispose();
 	}

--- a/src/ui/ChessColorSelector.java
+++ b/src/ui/ChessColorSelector.java
@@ -2,11 +2,14 @@ package ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dialog;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -30,7 +33,7 @@ public class ChessColorSelector extends JDialog {
 
 	private int selectedColor;
 
-	public ChessColorSelector() {
+	public ChessColorSelector(JPanel parent) {
 		selectedColor = -1;
 		int randomColor = Math.random() > 0.5 ? Piece.WHITE : Piece.BLACK;
 
@@ -46,16 +49,28 @@ public class ChessColorSelector extends JDialog {
 		JButton blackColorButton = createColorButton(Piece.BLACK, BLACK_COLOR_ICON);
 
 		buttonPanel.add(prompt, BorderLayout.NORTH);
-		buttonPanel.add(whiteColorButton, BorderLayout.EAST);
+		buttonPanel.add(whiteColorButton, BorderLayout.WEST);
 		buttonPanel.add(randomColorButton, BorderLayout.CENTER);
-		buttonPanel.add(blackColorButton, BorderLayout.WEST);
+		buttonPanel.add(blackColorButton, BorderLayout.EAST);
 
 		add(buttonPanel);
+
+		addWindowFocusListener(new WindowFocusListener() {
+			@Override
+			public void windowGainedFocus(WindowEvent e) {
+			}
+
+			@Override
+			public void windowLostFocus(WindowEvent e) {
+				dispose();
+			}
+		});
+
+		setUndecorated(true);
 		pack();
-		setIconImage(null);
-		setModal(true);
+		setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-		setLocationRelativeTo(null);
+		setLocationRelativeTo(parent);
 		setVisible(true);
 	}
 

--- a/src/ui/MainMenu.java
+++ b/src/ui/MainMenu.java
@@ -65,6 +65,7 @@ public class MainMenu extends JPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				int playerColor = getPlayerColor();
+				System.out.println("Got Color: " + playerColor);
 				if (playerColor != Piece.WHITE && playerColor != Piece.BLACK) {
 					parent.switchPanel(ChessFrame.MAIN_MENU);
 				} else {
@@ -108,7 +109,7 @@ public class MainMenu extends JPanel {
 	}
 
 	public int getPlayerColor() {
-		ChessColorSelector colorSelector = new ChessColorSelector();
+		ChessColorSelector colorSelector = new ChessColorSelector(this);
 		int selectedColor = colorSelector.getSelectedColor();
 
 		return selectedColor;

--- a/src/ui/PawnPromotionPrompt.java
+++ b/src/ui/PawnPromotionPrompt.java
@@ -1,0 +1,128 @@
+package ui;
+
+import java.awt.Color;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
+
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import chess.Piece;
+import chess.PieceType;
+import gui.ChessBoardPainter;
+import util.ImageUtil;
+
+public class PawnPromotionPrompt extends JDialog {
+
+	private static final long serialVersionUID = 1834479053981065833L;
+
+	private static final ImageIcon WQUEEN = new ImageIcon(ImageUtil.getImage(Piece.PIECE_PATH + "qw.png"));
+	private static final ImageIcon WKNIGHT = new ImageIcon(ImageUtil.getImage(Piece.PIECE_PATH + "nw.png"));
+	private static final ImageIcon WROOK = new ImageIcon(ImageUtil.getImage(Piece.PIECE_PATH + "rw.png"));
+	private static final ImageIcon WBISHOP = new ImageIcon(ImageUtil.getImage(Piece.PIECE_PATH + "bw.png"));
+
+	private static final ImageIcon BQUEEN = new ImageIcon(Piece.PIECE_PATH + "qb.png");
+	private static final ImageIcon BKNIGHT = new ImageIcon(Piece.PIECE_PATH + "nb.png");
+	private static final ImageIcon BROOK = new ImageIcon(Piece.PIECE_PATH + "rb.png");
+	private static final ImageIcon BBISHOP = new ImageIcon(Piece.PIECE_PATH + "bb.png");
+
+	private PieceType promotionSelection;
+
+	public PawnPromotionPrompt(int color, int x, int y) {
+		setUndecorated(true);
+		setPreferredSize(new Dimension(ChessBoardPainter.TILE_SIZE, 4 * ChessBoardPainter.TILE_SIZE));
+		setLocation(x, y);
+
+		JPanel promotionPanel = new JPanel();
+		promotionPanel.setLayout(new GridLayout(4, 0));
+
+		JButton queenButton;
+		JButton knightButton;
+		JButton rookButton;
+		JButton bishopButton;
+		if (color == Piece.WHITE) {
+			queenButton = createPromotionButton(PieceType.WQUEEN, WQUEEN);
+			knightButton = createPromotionButton(PieceType.WKNIGHT, WKNIGHT);
+			rookButton = createPromotionButton(PieceType.WROOK, WROOK);
+			bishopButton = createPromotionButton(PieceType.WBISHOP, WBISHOP);
+		} else {
+			queenButton = createPromotionButton(PieceType.BQUEEN, BQUEEN);
+			knightButton = createPromotionButton(PieceType.BKNIGHT, BKNIGHT);
+			rookButton = createPromotionButton(PieceType.BROOK, BROOK);
+			bishopButton = createPromotionButton(PieceType.BBISHOP, BBISHOP);
+		}
+		promotionPanel.add(queenButton);
+		promotionPanel.add(knightButton);
+		promotionPanel.add(rookButton);
+		promotionPanel.add(bishopButton);
+
+		addWindowFocusListener(new WindowFocusListener() {
+			@Override
+			public void windowGainedFocus(WindowEvent e) {
+			}
+
+			@Override
+			public void windowLostFocus(WindowEvent e) {
+				dispose();
+			}
+		});
+
+		add(promotionPanel);
+
+		pack();
+		setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
+		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		setVisible(true);
+	}
+
+	public PieceType getPromotionSelection() {
+		return promotionSelection;
+	}
+
+	private JButton createPromotionButton(PieceType promotionType, ImageIcon icon) {
+		JButton button = new JButton(icon);
+		button.setFocusPainted(false);
+		button.setBorderPainted(false);
+		button.setContentAreaFilled(false);
+		button.setOpaque(true);
+
+		Color backgroundColor = this.getBackground();
+		button.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				promotionSelection = promotionType;
+				closePrompt();
+			}
+
+		});
+
+		button.addMouseListener(new MouseAdapter() {
+			public void mouseEntered(MouseEvent evt) {
+				button.setBackground(backgroundColor.darker());
+			}
+
+			public void mouseExited(MouseEvent evt) {
+				button.setBackground(backgroundColor);
+			}
+		});
+
+		return button;
+	}
+
+	private void closePrompt() {
+		SwingUtilities.getWindowAncestor(this).dispose();
+	}
+
+}


### PR DESCRIPTION
Improves pawn promotion promt enabling the prompt to close on focus, highlight the piece the player is hovering over, and display the prompt on the appropriate square

Adds Observer design pattern to the GameManager and ChessBoardPainter to handle drawing based on specific moves